### PR TITLE
server: add setAlgoHost functionality

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -39,10 +39,50 @@ module.exports = class AlgoServer extends EventEmitter {
 
     this.db = db
     this.port = port
-    this.host = new AOHost({
-      aos, apiKey, apiSecret, agent, wsURL, restURL, db,
-    })
+    // If provided with order definitions then create the algoHost instance
+    // Mostly just for backwards compatibility
+    if (aos) {
+      host = new AOHost({
+        aos, apiKey, apiSecret, agent, wsURL, restURL, db,
+      })
+      this.setAlgoHost(host)
+    }
 
+    this.hbi = startHB(this)
+    this.wss = startWSS(this)
+  }
+
+  close () {
+    if (this.host) {
+      this.host.close()
+    }
+    this.wss.close()
+  }
+
+  /**
+   * Removes all of the event bindings from the current established algo host before calling
+   * for the algo host object to be closed. If there is no host established then this function
+   * is a no-op.
+   */
+  clearAlgoHost () {
+    if (this.host) {
+      // remove all events from old host
+      this.host.eventNames().forEach(eventName => this.host.removeAllListeners(eventName))
+      // close connection of old host
+      this.host.close()
+    }
+  }
+
+  /**
+   * Sets the event bindings to use the given algo host instance. This function
+   * also manages the closing of the old aoHos instance and the establishment of the
+   * new algohost instance.
+   * @param {Object} aoHost
+   */
+  setAlgoHost (aoHost) {
+    this.clearAlgoHost()
+    this.host = aoHost
+    // bind new events to new algo host
     this.host.on('ao:start', this.onAOStart)
     this.host.on('ao:stop', this.onAOStop)
     this.host.on('ws2:notification', this.onWSNotification)
@@ -50,18 +90,10 @@ module.exports = class AlgoServer extends EventEmitter {
     this.host.on('ws2:auth:success', this.onWSAuthSuccess)
     this.host.on('error', this.onError)
 
-    this.hbi = startHB(this)
-    this.wss = startWSS(this)
-
     // Give algo UIs time to upload to avoid nonce error
     setTimeout(() => {
       this.host.m.openWS()
     }, 5000)
-  }
-
-  close () {
-    this.host.close()
-    this.wss.close()
   }
 
   onAOStart (instance) {
@@ -101,6 +133,11 @@ module.exports = class AlgoServer extends EventEmitter {
     const req = splitType.splice(splitType.length - 1, 1)[0]
     const [ ucm, nType, ...idContents ] = splitType
 
+    // no algo host established
+    if (!this.host) {
+      return
+    }
+
     if (_last(idContents) === 'res') { // ignore responses
       return
     }
@@ -110,7 +147,6 @@ module.exports = class AlgoServer extends EventEmitter {
     if (ucm !== 'ucm' || req !== 'req') {
       return
     }
-
     if (nType === 'preview') {
       debug('recv preview for %s', id)
       this.onPreview(id, messageID, type, notifyInfo)


### PR DESCRIPTION
Currently you can only pass a set of algo order definitions into the algo server. What if we want to handle the algohost instance ourselves?

This PR lets you set the algo host instance whilst also maintaining backwards compatibility.