### PR TITLE
Fix duplication of AOhost instance

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+# 1.4.3
+- fix: when initiating a new server instance, correctly use the passed in host
+
 # 1.4.2
 - meta: bump bitfinex-api-node to v4
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,7 @@ class AlgoServer extends EventEmitter {
     this.onWSAuthSuccess = this.onWSAuthSuccess.bind(this)
     this.onError = this.onError.bind(this)
 
-    const { aos, port, db, adapter } = args
+    const { aos, port, db, adapter, host } = args
 
     this.db = db
     this.port = port
@@ -40,8 +40,12 @@ class AlgoServer extends EventEmitter {
 
     // If provided with order definitions then create the algoHost instance
     // Mostly just for backwards compatibility
-    if (aos) {
-      const host = new AOHost({ aos, db, adapter })
+    if (aos && !host) {
+      const aoh = new AOHost({ aos, db, adapter })
+      this.setAlgoHost(aoh)
+    }
+
+    if (host) {
       this.setAlgoHost(host)
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -104,7 +104,7 @@ class AlgoServer extends EventEmitter {
    * Sets the event bindings to use the given algo host instance. This function
    * also manages the closing of the old host instance and the establishment of
    * the new host instance.
-   * 
+   *
    * If the WebSocket API server is running, the exchange connection is opened.
    *
    * @param {Object} aoHost

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-algo-server",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "HF Algorithmic Order Server",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
### Description:

Previously algo orders were being duplicated due to the creation of 2 algo-host instances. This pull request solves that by only initiating a single instance of the AOhost.

Linked to https://github.com/bitfinexcom/bfx-hf-server/pull/35

### Breaking changes:
None

### New features:
None

### Fixes:
- [x] Only create a single instance of a AOhost

### PR status:
- [x] Version bumped
- [x] Change-log updated
